### PR TITLE
NoMethodError fix for Similar ClassNames and MethodNames

### DIFF
--- a/lib/did_you_mean/finders/name_error_finders/similar_class_finder.rb
+++ b/lib/did_you_mean/finders/name_error_finders/similar_class_finder.rb
@@ -5,6 +5,7 @@ module DidYouMean
 
     def initialize(exception)
       @class_name, @original_message = exception.name, exception.original_message
+      autoload_class_name_inflector
     end
 
     def words
@@ -31,6 +32,16 @@ module DidYouMean
     end
 
     private
+
+    def autoload_class_name_inflector
+      return unless defined?(Rails)
+      class_name_inflector = class_name_is_singular? ? class_name.to_s.pluralize : class_name.to_s.singularize
+      class_name_inflector.safe_constantize
+    end
+
+    def class_name_is_singular?
+      class_name.to_s.pluralize.singularize == class_name.to_s
+    end
 
     def scope_base
       @scope_base ||= (/(([A-Z]\w*::)*)([A-Z]\w*)$/ =~ original_message ? $1 : "").split("::")

--- a/lib/did_you_mean/finders/similar_method_finder.rb
+++ b/lib/did_you_mean/finders/similar_method_finder.rb
@@ -1,21 +1,57 @@
+require 'ostruct'
+
 module DidYouMean
   class SimilarMethodFinder
     include BaseFinder
     attr_reader :method_name, :receiver
 
-    def initialize(exception)
+    def initialize(exception, base_class_name = nil)
       @method_name = exception.name
       @receiver    = exception.receiver
-      @separator   = @receiver.is_a?(Class) ? DOT : POUND
+      @original_message = exception.original_message
+      @base_class_name = base_class_name
     end
 
     def words
       (receiver.methods + receiver.singleton_methods).uniq.map do |name|
-        StringDelegator.new(name.to_s, :method, prefix: @separator)
+        StringDelegator.new(name.to_s, :method, prefix: prefix)
       end
     end
 
+    def suggestions
+      methods = @base_class_name ? super.map(&:with_prefix) : super
+      methods + similar_classes_method_suggestions
+    end
+
     alias target_word method_name
+
+    private
+
+    def prefix
+      @prefix ||= begin
+        separator = @base_class_name.to_s
+        separator << (receiver_is_class_or_method? ? DOT : POUND)
+      end
+    end
+
+    def receiver_is_class_or_method?
+      @receiver.is_a?(Class) || @receiver.is_a?(Module)
+    end
+
+    def similar_classes_method_suggestions
+      return [] unless receiver_is_class_or_method? && !@base_class_name
+      similar_class_suggestions.flat_map do |suggestion|
+          exception = OpenStruct.new name: @method_name, receiver: Kernel.const_get(suggestion.to_s), original_message: @original_message
+          SimilarMethodFinder.new(exception, suggestion.to_s).suggestions
+        end
+    end
+
+    def similar_class_suggestions
+      exception = OpenStruct.new name: @receiver, original_message: @original_message
+      SimilarClassFinder.new(exception).suggestions.
+        select { |suggestion| suggestion.to_s != @receiver.to_s }.
+        map(&:with_prefix)
+    end
   end
 
   finders["NoMethodError"] = SimilarMethodFinder

--- a/lib/did_you_mean/test_helper.rb
+++ b/lib/did_you_mean/test_helper.rb
@@ -1,7 +1,7 @@
 module DidYouMean
   module TestHelper
     def assert_suggestion(array, expected)
-      assert_equal [expected], array, "Expected #{array.inspect} to only include #{expected.inspect}"
+      assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
     end
   end
 end

--- a/test/similar_method_finder_test.rb
+++ b/test/similar_method_finder_test.rb
@@ -1,23 +1,6 @@
 require_relative 'test_helper'
 
 class SimilarMethodFinderTest < Minitest::Test
-  class User
-    def friends; end
-    def first_name; end
-    def descendants; end
-
-    private
-
-    def friend; end
-
-    class << self
-      def load; end
-    end
-  end
-
-  module UserModule
-    def from_module; end
-  end
 
   def setup
     user = User.new.extend(UserModule)
@@ -26,6 +9,8 @@ class SimilarMethodFinderTest < Minitest::Test
     @error_from_private_method  = assert_raises(NoMethodError){ user.friend }
     @error_from_module_method   = assert_raises(NoMethodError){ user.fr0m_module }
     @error_from_class_method    = assert_raises(NoMethodError){ User.l0ad }
+    @error_from_similar_class_method  = assert_raises(NoMethodError){ Users.last_name }
+    @error_from_similar_module_method  = assert_raises(NoMethodError){ Users.pass }
   end
 
   def test_similar_words
@@ -33,6 +18,8 @@ class SimilarMethodFinderTest < Minitest::Test
     assert_suggestion @error_from_private_method.suggestions,  "friends"
     assert_suggestion @error_from_module_method.suggestions,   "from_module"
     assert_suggestion @error_from_class_method.suggestions,    "load"
+    assert_suggestion @error_from_similar_class_method.suggestions,    %w{last_names User.last_name}
+    assert_suggestion @error_from_similar_module_method.suggestions,    %w{hash class User.pass User.hash User.class}
   end
 
   def test_did_you_mean?
@@ -40,10 +27,44 @@ class SimilarMethodFinderTest < Minitest::Test
     assert_match "Did you mean? #friends",     @error_from_private_method.did_you_mean?
     assert_match "Did you mean? #from_module", @error_from_module_method.did_you_mean?
     assert_match "Did you mean? .load",        @error_from_class_method.did_you_mean?
+    assert_match "Did you mean? .last_names\n                  User.last_name",        @error_from_similar_class_method.did_you_mean?
+    assert_match ["Did you mean? .hash", ".class", "User.pass", "User.hash", "User.class" ].join("\n                  "),        @error_from_similar_module_method.did_you_mean?
   end
 
   def test_similar_words_for_long_method_name
     error = assert_raises(NoMethodError){ User.new.dependents }
     assert_suggestion error.suggestions, "descendants"
+  end
+end
+
+class User
+  def friends; end
+  def first_name; end
+  def descendants; end
+
+  class << self
+    def last_name; end
+  end
+
+  class << self
+    def pass; end
+  end
+
+  private
+
+  def friend; end
+
+  class << self
+    def load; end
+  end
+end
+
+module UserModule
+  def from_module; end
+end
+
+module Users
+  class << self
+    def last_names; end
   end
 end


### PR DESCRIPTION
These code changes resolve #24 using the SimilarMethodFinder and SimilarClassFinder.

(deleted previous pull request as I hadn't updated my copy from master)

Checks to see if the receiver is a Class or Module
If Class or Module, then use SimilarClassFinder for classes other than current receiver
For each SimilarClass use SimilarMethodFinder
Return Results
I also noticed that when in Rails using development mode and cache_class set to false if I have 2 classes (User and Users), and I attempt to access the active record model (e.g. Users.first), the suggestion "Did you mean? User.first" still didn't work unless I had already loaded the User class. I see users do this all the time with active record models, forgetting the plural vs singular form.

So, I added a simple method (if Rails is loaded) that takes the receiver class and attempts to autoload a safe_contantize of the pluralized or singular version of the Class name (see autoload_class_name_inflector). This resolves the issue.