### PR TITLE
NoMethodError fix for Similar ClassNames and MethodNames

### DIFF
--- a/lib/did_you_mean/finders/name_error_finders/similar_class_finder.rb
+++ b/lib/did_you_mean/finders/name_error_finders/similar_class_finder.rb
@@ -5,6 +5,7 @@ module DidYouMean
 
     def initialize(exception)
       @class_name, @original_message = exception.name, exception.original_message
+      autoload_class_name_inflector
     end
 
     def words
@@ -31,6 +32,13 @@ module DidYouMean
     end
 
     private
+
+    def autoload_class_name_inflector
+      return unless defined?(Rails)
+      name_is_singular = name_from_message.to_s.pluralize.singularize == name_from_message.to_s
+      class_name_inflector = name_is_singular ? name_from_message.to_s.pluralize : name_from_message.to_s.singularize
+      class_name_inflector.safe_constantize
+    end
 
     def scope_base
       @scope_base ||= (/(([A-Z]\w*::)*)([A-Z]\w*)$/ =~ original_message ? $1 : "").split("::")

--- a/lib/did_you_mean/finders/similar_method_finder.rb
+++ b/lib/did_you_mean/finders/similar_method_finder.rb
@@ -1,21 +1,68 @@
+require 'ostruct'
+
 module DidYouMean
   class SimilarMethodFinder
     include BaseFinder
     attr_reader :method_name, :receiver
 
-    def initialize(exception)
+    def initialize(exception, base_class_name = nil)
       @method_name = exception.name
       @receiver    = exception.receiver
-      @separator   = @receiver.is_a?(Class) ? DOT : POUND
+      @original_message = exception.original_message
+      @base_class_name = base_class_name
     end
 
     def words
       (receiver.methods + receiver.singleton_methods).uniq.map do |name|
-        StringDelegator.new(name.to_s, :method, prefix: @separator)
+        StringDelegator.new(name.to_s, :method, prefix: prefix)
       end
     end
 
+    def suggestions
+      methods = @base_class_name ? super.map(&:with_prefix) : super
+      methods + similar_classes_method_suggestions
+    end
+
     alias target_word method_name
+
+    private
+
+    def prefix
+      @prefix ||= begin
+        separator = @base_class_name.to_s
+        separator << (receiver_is_class_or_method? ? DOT : POUND)
+      end
+    end
+
+    def receiver_is_class_or_method?
+      @receiver.is_a?(Class) || @receiver.is_a?(Module)
+    end
+
+    def similar_classes_method_suggestions
+      return [] unless receiver_is_class_or_method? && !@base_class_name
+      similar_class_suggestions.flat_map do |suggestion|
+        SimilarMethodFinder.new(*similar_method_finder_params(suggestion.to_s)).suggestions
+      end
+    end
+
+    def similar_method_finder_params(class_name)
+      exception = OpenStruct.new(
+        name: @method_name,
+        receiver: Kernel.const_get(class_name),
+        original_message: @original_message
+      )
+      [exception, class_name]
+    end
+
+    def similar_class_suggestions
+      exception = OpenStruct.new original_message: @original_message.gsub(/:(Module|Class)$/, '')
+      SimilarClassFinder.new(exception).suggestions
+        .select do |suggestion|
+          const = Kernel.const_get(suggestion.to_s)
+          (const.is_a?(Class) || const.is_a?(Module)) && suggestion.to_s != @receiver.to_s
+        end
+        .map(&:with_prefix)
+    end
   end
 
   finders["NoMethodError"] = SimilarMethodFinder

--- a/lib/did_you_mean/test_helper.rb
+++ b/lib/did_you_mean/test_helper.rb
@@ -1,7 +1,7 @@
 module DidYouMean
   module TestHelper
     def assert_suggestion(array, expected)
-      assert_equal [expected], array, "Expected #{array.inspect} to only include #{expected.inspect}"
+      assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
     end
   end
 end

--- a/lib/did_you_mean/word_collection.rb
+++ b/lib/did_you_mean/word_collection.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'did_you_mean/levenshtein'
 
 module DidYouMean
@@ -14,8 +15,10 @@ module DidYouMean
     def similar_to(target_word)
       target_word = target_word.to_s
       threshold   = threshold(target_word)
-
-      select {|word| Levenshtein.distance(word.to_s, target_word) <= threshold }
+      map { |word| [Levenshtein.distance(word.to_s, target_word), word] }
+        .select { |distance, _| distance <= threshold }
+        .sort { |a, b| a[0] <=> b[0] }
+        .map { |_, word| word }
     end
 
     private

--- a/test/similar_method_finder_test.rb
+++ b/test/similar_method_finder_test.rb
@@ -1,10 +1,19 @@
 require_relative 'test_helper'
 
 class SimilarMethodFinderTest < Minitest::Test
+
   class User
     def friends; end
     def first_name; end
     def descendants; end
+
+    class << self
+      def last_name; end
+    end
+
+    class << self
+      def pass; end
+    end
 
     private
 
@@ -19,6 +28,12 @@ class SimilarMethodFinderTest < Minitest::Test
     def from_module; end
   end
 
+  module Users
+    class << self
+      def last_names; end
+    end
+  end
+
   def setup
     user = User.new.extend(UserModule)
 
@@ -26,6 +41,9 @@ class SimilarMethodFinderTest < Minitest::Test
     @error_from_private_method  = assert_raises(NoMethodError){ user.friend }
     @error_from_module_method   = assert_raises(NoMethodError){ user.fr0m_module }
     @error_from_class_method    = assert_raises(NoMethodError){ User.l0ad }
+
+    @error_from_similar_class_method  = assert_raises(NoMethodError){ Users.last_name }
+    @error_from_similar_module_method  = assert_raises(NoMethodError){ Users.pass }
   end
 
   def test_similar_words
@@ -33,6 +51,9 @@ class SimilarMethodFinderTest < Minitest::Test
     assert_suggestion @error_from_private_method.suggestions,  "friends"
     assert_suggestion @error_from_module_method.suggestions,   "from_module"
     assert_suggestion @error_from_class_method.suggestions,    "load"
+
+    assert_suggestion @error_from_similar_class_method.suggestions,  %w{last_names SimilarMethodFinderTest::User.last_name}
+    assert_suggestion @error_from_similar_module_method.suggestions, %w{hash class SimilarMethodFinderTest::User.pass SimilarMethodFinderTest::User.hash SimilarMethodFinderTest::User.class}
   end
 
   def test_did_you_mean?
@@ -40,6 +61,13 @@ class SimilarMethodFinderTest < Minitest::Test
     assert_match "Did you mean? #friends",     @error_from_private_method.did_you_mean?
     assert_match "Did you mean? #from_module", @error_from_module_method.did_you_mean?
     assert_match "Did you mean? .load",        @error_from_class_method.did_you_mean?
+    assert_match "Did you mean? .last_names\n                  SimilarMethodFinderTest::User.last_name",  @error_from_similar_class_method.did_you_mean?
+    assert_match ["Did you mean? .hash",
+                  ".class",
+                  "SimilarMethodFinderTest::User.pass",
+                  "SimilarMethodFinderTest::User.hash",
+                  "SimilarMethodFinderTest::User.class"
+                 ].join("\n                  "), @error_from_similar_module_method.did_you_mean?
   end
 
   def test_similar_words_for_long_method_name


### PR DESCRIPTION
(deleted previous pull requests to make it cleaner)

These code changes resolve #24 using the SimilarMethodFinder and SimilarClassFinder.

* Checks to see if the receiver is a Class or Module
* If Class or Module, then use SimilarClassFinder for classes other than current receiver
* For each SimilarClass use SimilarMethodFinder
* Return Results

I also noticed that when in Rails using development mode and cache_class set to false if I have 2 classes (User and Users), and I attempt to access the active record model (e.g. Users.first), the suggestion "Did you mean? User.first" still didn't work unless I had already loaded the User class. I see users do this all the time with active record models, forgetting the plural vs singular form.

To solve this, I added a simple method (if Rails is loaded) that takes the receiver class and attempts to autoload a safe_contantize of the pluralized or singular version of the Class name (see autoload_class_name_inflector). This resolves the issue.

Also improved the order in which suggestions are recommended.