### PR TITLE
NoMethodError fix for Similar ClassNames and MethodNames

### DIFF
--- a/lib/did_you_mean/finders/similar_class_method_finder.rb
+++ b/lib/did_you_mean/finders/similar_class_method_finder.rb
@@ -1,0 +1,56 @@
+require 'ostruct'
+
+module DidYouMean
+  class SimilarClassMethodFinder
+
+    def initialize(exception)
+      @method_name = exception.name
+      @receiver    = exception.receiver
+      @original_message = exception.original_message
+    end
+
+    def suggestions
+      return [] unless receiver_is_class_or_method?
+      similar_class_suggestions.flat_map do |suggestion|
+        SimilarMethodFinder.new(*similar_method_finder_params(suggestion.to_s)).suggestions
+      end
+    end
+
+    private
+
+    def receiver_is_class_or_method?
+      @receiver.is_a?(Class) || @receiver.is_a?(Module)
+    end
+
+    def similar_class_suggestions
+      SimilarClassFinder.new(similar_class_suggestions_exception).suggestions
+        .select { |suggestion| is_similar_class?(suggestion.to_s) }
+        .map(&:with_prefix)
+    end
+
+    def is_similar_class?(class_name)
+      return false if is_receiver_class?(class_name)
+      const = Kernel.const_get(class_name)
+      const.is_a?(Class) || const.is_a?(Module)
+    end
+
+    def is_receiver_class?(class_name)
+      class_name == @receiver.to_s
+    end
+
+
+    def similar_class_suggestions_exception
+      OpenStruct.new original_message: @original_message.gsub(/:(Module|Class)$/, '')
+    end
+
+    def similar_method_finder_params(class_name)
+      exception = OpenStruct.new(
+        name: @method_name,
+        receiver: Kernel.const_get(class_name),
+        original_message: @original_message
+      )
+      [exception, class_name]
+    end
+
+  end
+end

--- a/lib/did_you_mean/finders/similar_method_finder.rb
+++ b/lib/did_you_mean/finders/similar_method_finder.rb
@@ -1,21 +1,52 @@
+require 'did_you_mean/finders/similar_class_method_finder'
+
 module DidYouMean
   class SimilarMethodFinder
     include BaseFinder
     attr_reader :method_name, :receiver
 
-    def initialize(exception)
+    def initialize(exception, similar_class_name = nil)
       @method_name = exception.name
       @receiver    = exception.receiver
-      @separator   = @receiver.is_a?(Class) ? DOT : POUND
+      @exception = exception
+      @similar_class = similar_class_name || ''
     end
 
     def words
       (receiver.methods + receiver.singleton_methods).uniq.map do |name|
-        StringDelegator.new(name.to_s, :method, prefix: @separator)
+        StringDelegator.new(name.to_s, :method, prefix: prefix)
+      end
+    end
+
+    def suggestions
+      if @similar_class.empty?
+        super + similar_class_method_suggestions
+      else
+        super.map(&:with_prefix)
       end
     end
 
     alias target_word method_name
+
+    private
+
+    def prefix
+      @prefix ||= @similar_class + separator
+    end
+
+    def separator
+      receiver_is_module_or_class? ? DOT : POUND
+    end
+
+    def receiver_is_module_or_class?
+      receiver.is_a?(Module) || receiver.is_a?(Class)
+    end
+
+    def similar_class_method_suggestions
+      return [] unless receiver_is_module_or_class?
+      SimilarClassMethodFinder.new(@exception).suggestions
+    end
+
   end
 
   finders["NoMethodError"] = SimilarMethodFinder

--- a/lib/did_you_mean/test_helper.rb
+++ b/lib/did_you_mean/test_helper.rb
@@ -3,5 +3,9 @@ module DidYouMean
     def assert_suggestion(array, expected)
       assert_equal [expected], array, "Expected #{array.inspect} to only include #{expected.inspect}"
     end
+
+    def assert_suggestions(array, expected)
+      assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
+    end
   end
 end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -2,6 +2,7 @@ require_relative 'null_finder_test'
 require_relative 'name_error_extension_test'
 require_relative 'similar_name_finder_test'
 require_relative 'similar_method_finder_test'
+require_relative 'similar_class_method_finder_test'
 require_relative 'no_method_error_extension_test'
 
 if defined?(ActiveRecord)

--- a/test/similar_class_method_finder_test.rb
+++ b/test/similar_class_method_finder_test.rb
@@ -1,0 +1,41 @@
+require_relative 'test_helper'
+
+class SimilarClassMethodFinderTest < Minitest::Test
+
+  class User
+    class << self
+      def last_name; end
+    end
+
+    class << self
+      def pass; end
+    end
+  end
+
+  module Users
+    class << self
+      def last_names; end
+    end
+  end
+
+  def setup
+    @error_from_similar_class_method  = assert_raises(NoMethodError){ Users.last_name }
+    @error_from_similar_module_method  = assert_raises(NoMethodError){ Users.pass }
+  end
+
+  def test_similar_words
+    assert_suggestions @error_from_similar_class_method.suggestions,  %w{last_names SimilarClassMethodFinderTest::User.last_name}
+    assert_suggestions @error_from_similar_module_method.suggestions, %w{hash class SimilarClassMethodFinderTest::User.pass SimilarClassMethodFinderTest::User.hash SimilarClassMethodFinderTest::User.class}
+  end
+
+  def test_did_you_mean?
+    assert_match "Did you mean? .last_names\n                  SimilarClassMethodFinderTest::User.last_name",  @error_from_similar_class_method.did_you_mean?
+    assert_match ["Did you mean? .hash",
+                  ".class",
+                  "SimilarClassMethodFinderTest::User.pass",
+                  "SimilarClassMethodFinderTest::User.hash",
+                  "SimilarClassMethodFinderTest::User.class"
+                 ].join("\n                  "), @error_from_similar_module_method.did_you_mean?
+  end
+
+end


### PR DESCRIPTION
These code changes resolve #24 using the SimilarMethodFinder and SimilarClassFinder.

* Checks to see if the receiver is a Class or Module
* If Class or Module, then use SimilarClassFinder for classes other than current receiver
* For each SimilarClass use SimilarMethodFinder
* Return Results