### PR TITLE
Prioritize suggestions with only case changes

### DIFF
--- a/lib/did_you_mean/levenshtein.rb
+++ b/lib/did_you_mean/levenshtein.rb
@@ -8,6 +8,8 @@ module DidYouMean
       return m if n.zero?
       return n if m.zero?
 
+      return 1 if str1.downcase == str2.downcase && str1 != str2
+
       d = (0..m).to_a
       x = nil
 

--- a/test/similar_class_finder_test.rb
+++ b/test/similar_class_finder_test.rb
@@ -1,5 +1,8 @@
 require_relative 'test_helper'
 
+module ACRONYM
+end
+
 class Project
   def self.bo0k
     Bo0k
@@ -31,6 +34,16 @@ class SimpleSimilarClassFinderTest < Minitest::Test
 
   def test_similar_words
     assert_suggestion @error.suggestions, "Book"
+  end
+end
+
+class CaseSpecificClassFinderTest < Minitest::Test
+  def setup
+    @error = assert_raises(NameError) { ::Acronym }
+  end
+
+  def test_similar_words
+    assert_suggestion @error.suggestions, "ACRONYM"
   end
 end
 


### PR DESCRIPTION
Prioritize suggestions where the only changes are upper-casing or
lower-casing characters in the string, by short-circuiting the
Levenshtein distance algorithm to return 1 if the strings are just
different-cased versions of each other.

There is almost definitely a better-optimized way of implementing this.

Fixes #38