### PR TITLE
Create a list of backtrace that is 6-depth only

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -12,7 +12,7 @@ class NameError
 
   def to_s
     msg = original_message
-    bt  = caller.first(6)
+    bt  = caller(1, 6)
 
     msg << did_you_mean?.to_s if IGNORED_CALLERS.all? {|ignored| bt.grep(ignored).empty? }
     msg


### PR DESCRIPTION
Calling `#caller` without arguments creates a whole list of backtrace. This reduces about some of the memory usage depending on how deep the system stack is, but doesn't work with Ruby 1.9.3. Let's merge this when we drop support for Ruby 1.9.3.

[The full report can be found here.](https://gist.github.com/yuki24/5025a7b8603c25dcdd89/revisions)

```diff
@@ -1,14 +1,14 @@
-#### Total allocated 4510
-#### Total retained 12
+#### Total allocated 4010
+#### Total retained 13
 
 allocated memory by gem
 -----------------------------------
-    585956  did_you_mean/lib
+    518156  did_you_mean/lib
       3624  other
 
 allocated memory by file
 -----------------------------------
-    408369  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb
+    340569  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb
      68700  /GitHub/did_you_mean/lib/did_you_mean/formatters.rb
      34496  /GitHub/did_you_mean/lib/did_you_mean/finders/name_error_finders/similar_name_finder.rb
      27532  /GitHub/did_you_mean/lib/did_you_mean/word_collection.rb
@@ -19,7 +19,7 @@ allocated memory by file
 
 allocated memory by location
 -----------------------------------
-    239600  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:15
+    171800  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:15
      99600  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:17
      60809  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:11
      28800  /GitHub/did_you_mean/lib/did_you_mean/finders/name_error_finders/similar_name_finder.rb:10
@@ -54,12 +54,12 @@ allocated memory by location
 
 allocated objects by gem
 -----------------------------------
-      4504  did_you_mean/lib
+      4004  did_you_mean/lib
          6  other
 
 allocated objects by file
 -----------------------------------
-      2605  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb
+      2105  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb
        800  /GitHub/did_you_mean/lib/did_you_mean/formatters.rb
        387  /GitHub/did_you_mean/lib/did_you_mean/finders/name_error_finders/similar_name_finder.rb
        311  /GitHub/did_you_mean/lib/did_you_mean/word_collection.rb
@@ -70,7 +70,7 @@ allocated objects by file
 
 allocated objects by location
 -----------------------------------
-      1300  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:15
+       800  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:15
        601  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:11
        600  /GitHub/did_you_mean/lib/did_you_mean/core_ext/name_error.rb:17
        360  /GitHub/did_you_mean/lib/did_you_mean/finders/name_error_finders/similar_name_finder.rb:10
```