### PR TITLE
Rubocop lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test/tmp
 test/version_tmp
 tmp
 log
+.tags*
 
 evaluation/dictionary.yml
 benchmark/results

--- a/benchmark/memory_usage.rb
+++ b/benchmark/memory_usage.rb
@@ -14,7 +14,7 @@ class DidYouMean::WordCollection
     @words = words
   end
 
-  def similar_to(input, filter = '')
+  def similar_to(input, _ = '')
     @corrections, @input = nil, input
     corrections
   end

--- a/evaluation/calculator.rb
+++ b/evaluation/calculator.rb
@@ -46,7 +46,7 @@ report "loading program" do
       @words = words
     end
 
-    def similar_to(input, filter = '')
+    def similar_to(input, _ = '')
       @corrections, @input = nil, input
       corrections
     end

--- a/evaluation/dictionary_generator.rb
+++ b/evaluation/dictionary_generator.rb
@@ -5,7 +5,6 @@ require 'json'
 per_page = 500
 base_url = "https://simple.wiktionary.org/w/api.php?action=query&aplimit=#{per_page}&list=allpages&format=json"
 filename = "evaluation/dictionary.yml"
-count    = nil
 apfrom   = ""
 num      = 0
 titles   = []

--- a/evaluation/dictionary_generator.rb
+++ b/evaluation/dictionary_generator.rb
@@ -9,7 +9,7 @@ apfrom   = ""
 num      = 0
 titles   = []
 
-begin
+loop do
   url = base_url + "&apfrom=#{apfrom}"
 
   puts "downloading page %2d: #{url}" % num
@@ -21,7 +21,9 @@ begin
 
   titles += json["query"]["allpages"].map {|hash| hash["title"] }
   num    += 1
-end while count == per_page
+
+  break if count != per_page
+end
 
 require 'yaml'
 

--- a/lib/did_you_mean/jaro_winkler.rb
+++ b/lib/did_you_mean/jaro_winkler.rb
@@ -42,11 +42,11 @@ module DidYouMean
           j = index = k
 
           k = while j < length2
-            index = j
-            break(j + 1) if flags2[j] != 0
+                index = j
+                break(j + 1) if flags2[j] != 0
 
-            j += 1
-          end
+                j += 1
+              end
 
           t += 1 if str1_codepoints[i] != str2_codepoints[index]
         end

--- a/lib/did_you_mean/spell_checkable.rb
+++ b/lib/did_you_mean/spell_checkable.rb
@@ -19,16 +19,16 @@ module DidYouMean
         has_mistype = seed.rindex {|c| Levenshtein.distance(normalize(c), input) <= threshold }
 
         corrections = if has_mistype
-          seed.take(has_mistype + 1)
-        else
-          # Correct misspells
-          seed.select do |candidate|
-            candidate = normalize(candidate)
-            length    = input.length < candidate.length ? input.length : candidate.length
+                        seed.take(has_mistype + 1)
+                      else
+                        # Correct misspells
+                        seed.select do |candidate|
+                          candidate = normalize(candidate)
+                          length    = input.length < candidate.length ? input.length : candidate.length
 
-            Levenshtein.distance(candidate, input) < length
-          end.first(1)
-        end
+                          Levenshtein.distance(candidate, input) < length
+                        end.first(1)
+                      end
 
         corrections
       end

--- a/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
@@ -27,8 +27,8 @@ module DidYouMean
     end
 
     def scopes
-      @scopes ||= @receiver.to_s.split("::").inject([Object]) do |_scopes, scope|
-        _scopes << _scopes.last.const_get(scope)
+      @scopes ||= @receiver.to_s.split("::").inject([Object]) do |s, scope|
+        s << _scopes.last.const_get(scope)
       end.uniq
     end
 

--- a/test/extra_features/initializer_name_correction_test.rb
+++ b/test/extra_features/initializer_name_correction_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class InitializerNameCorrectionTest < Minitest::Test
   def test_corrects_wrong_initializer_name
     assert_output nil, "warning: intialize might be misspelled, perhaps you meant initialize?\n" do
-      Class.new { def intialize; end }
+      Class.new -> { intialize }
     end
   end
 
   def test_does_not_correct_correct_initializer_name
     assert_output nil, "" do
-      Class.new { def initialize; end }
+      Class.new -> { initialize }
     end
   end
 end


### PR DESCRIPTION
Let's have a rubocop lint for good ruby code! Fixing all warnings including style or metrics is too much, so I started from only lint. There are still some warnings, but it's due to a ruby2.3 feature, testing and so on. Thus, we can skip them.

```shell
% rubocop -l
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.x-compliant syntax, but you are running 2.3.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 38 files
.........W.........E...........W.....F

Offenses:

evaluation/calculator.rb:39:3: W: Do not suppress exceptions.
  rescue LoadError, NameError
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/did_you_mean/spell_checkers/method_name_checker.rb:9:38: E: unexpected token tDOT
      @has_args    = !exception.args&.empty?
                                     ^
test/correctable/variable_name_test.rb:53:5: W: Useless assignment to variable - person. Did you mean eprson?
    person = person = nil
    ^^^^^^
test/correctable/variable_name_test.rb:53:14: W: Useless assignment to variable - person. Did you mean eprson?
    person = person = nil
             ^^^^^^
test/verbose_formatter_test.rb:10:34: E: unexpected token tCOMMA
    assert_equal <<~MESSAGE.chomp, @error.message
                                 ^
test/verbose_formatter_test.rb:11:42: F: unterminated string meets end of file
      undefined local variable or method `doesnt_exist' for #{method(:to_s).super_method.call}
                                         ^

38 files inspected, 6 offenses detected
```