### PR TITLE
Implement `KeyError` checker

### DIFF
--- a/lib/did_you_mean/extra_features.rb
+++ b/lib/did_you_mean/extra_features.rb
@@ -14,3 +14,4 @@ end
 
 require 'did_you_mean/extra_features/initializer_name_correction'
 require 'did_you_mean/extra_features/ivar_name_correction'
+require 'did_you_mean/extra_features/key_error'

--- a/lib/did_you_mean/extra_features/key_error.rb
+++ b/lib/did_you_mean/extra_features/key_error.rb
@@ -1,0 +1,33 @@
+module DidYouMean
+  module ExtraFeatures
+    module KeyErrorWithNameAndKeys
+      def fetch(name, *)
+        super
+      rescue KeyError => e
+        e.instance_variable_set(:@name, name)
+        e.instance_variable_set(:@keys, keys)
+        raise e
+      end
+    end
+    Hash.prepend KeyErrorWithNameAndKeys
+    KeyError.send(:attr, :name, :keys)
+
+    class KeyNameChecker
+      include SpellCheckable
+      def initialize(key_error)
+        @name = key_error.name
+        @keys = key_error.keys
+      end
+
+      def candidates
+        { @name => @keys }
+      end
+
+      def corrections
+        super.map(&:inspect)
+      end
+    end
+    SPELL_CHECKERS["KeyError"] = KeyNameChecker
+    KeyError.prepend DidYouMean::Correctable
+  end
+end

--- a/lib/did_you_mean/extra_features/key_error.rb
+++ b/lib/did_you_mean/extra_features/key_error.rb
@@ -1,11 +1,14 @@
 module DidYouMean
   module ExtraFeatures
     module KeyErrorWithNameAndKeys
+      FILE_REGEXP = %r"#{Regexp.quote(__FILE__)}"
+
       def fetch(name, *)
         super
       rescue KeyError => e
         e.instance_variable_set(:@name, name)
         e.instance_variable_set(:@keys, keys)
+        $@.delete_if { |s| FILE_REGEXP =~ s } if $@
         raise e
       end
     end

--- a/test/extra_features/key_error_test.rb
+++ b/test/extra_features/key_error_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class KeyErrorWithExtraFeaturesTest < Minitest::Test
+  def test_corrects_hash_key_name
+    hash = { "foo" => 1, bar: 2 }
+
+    error = assert_raises(KeyError) { hash.fetch(:bax) }
+    assert_correction ":bar", error.corrections
+    assert_match "Did you mean?  :bar", error.to_s
+
+    error = assert_raises(KeyError) { hash.fetch("fooo") }
+    assert_correction %("foo"), error.corrections
+    assert_match %(Did you mean?  "foo"), error.to_s
+  end
+end


### PR DESCRIPTION
I try experimental implementation of catch the `KeyError`.

```ruby
hash = {foo: 1, bar: 2, baz: 3}
hash.fetch(:fooo)
# KeyError: key not found: :fooo
# Did you mean?  :foo
```