### PR TITLE
Support Struct#[] and Struct#[]= typo

### DIFF
--- a/lib/did_you_mean/spell_checkers/name_error_checkers.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers.rb
@@ -11,7 +11,10 @@ module DidYouMean
       case exception.original_message
       when /uninitialized constant/
         ClassNameChecker
-      when /undefined local variable or method/, /undefined method/, /uninitialized class variable/
+      when /undefined local variable or method/,
+           /undefined method/,
+           /uninitialized class variable/,
+           /no member '.*' in struct/
         VariableNameChecker
       else
         NullChecker

--- a/test/core_ext/name_error_extension_test.rb
+++ b/test/core_ext/name_error_extension_test.rb
@@ -36,6 +36,18 @@ class NameErrorExtensionTest < Minitest::Test
     error.to_s
     assert_equal 1, error.to_s.scan("Did you mean?").count
   end
+
+  def test_struct_name_error
+    check_name_struct = Struct.new(:check_name)
+    error = assert_raises(NameError) do
+      check_name_struct.new[:doesnt_exist]
+    end
+
+    assert_equal <<~MESSAGE.chomp, error.to_s
+      no member 'doesnt_exist' in struct
+      Did you mean?  does_exist
+    MESSAGE
+  end
 end
 
 class IgnoreCallersTest < Minitest::Test


### PR DESCRIPTION
Actually, We cannot suggest from did_you_mean when typo at `Struct#[]` and `Struct#[]=` key.

```ruby
Foo = Struct.new(:foo)
Foo.new[:fooo]
#=> NameError: no member 'fooo' in struct
```

I want to save this case.

```ruby
Foo = Struct.new(:foo)
Foo.new[:fooo]
#=> NameError: no member 'fooo' in struct
Did you mean?  foo
               foo=
```

Now, `"no member ..."` message only make from here https://github.com/ksss/ruby/blob/cee9c58ef214cbbf10aedacd79c3b796eb5bba8e/struct.c#L868
