### PR TITLE
Fix Birkbeck Spelling Error Corpus filename

### DIFF
--- a/evaluation/incorrect_words.yaml
+++ b/evaluation/incorrect_words.yaml
@@ -1,5 +1,5 @@
 # This data is based on Birkbeck Spelling Error Corpus: http://ota.ox.ac.uk/headers/0643.xml
-# More specifically, this is a yaml version of the data in FAWTHROP1DAT.643 and FAWTHROP1DAT.643.
+# More specifically, this is a yaml version of the data in FAWTHROP1DAT.643 and FAWTHROP2DAT.643.
 ---
 abattoir: abbatoir
 abhorrence: abhorence


### PR DESCRIPTION
The original comment included the same filename twice.