### PR TITLE
Update did-you-mean spec

### DIFF
--- a/did_you_mean.gemspec
+++ b/did_you_mean.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0dev'
+  spec.required_ruby_version = '>= 2.4.0-dev'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Ran across error installing when it required 'Ruby version >= 2.4.0dev' rather than the version '2.4.0-dev'