### PR TITLE
Call uniq on spell checker corrections

### DIFF
--- a/lib/did_you_mean/spell_checker.rb
+++ b/lib/did_you_mean/spell_checker.rb
@@ -32,7 +32,7 @@ module DidYouMean
         end.first(1)
       end
 
-      corrections
+      corrections.uniq
     end
 
     private

--- a/test/spell_checker_test.rb
+++ b/test/spell_checker_test.rb
@@ -12,7 +12,7 @@ class SpellCheckerTest < Minitest::Test
     assert_spell 'sub',   input: 'suv',   dictionary: ['sub', 'gsub', 'sub!']
 
     assert_spell %w(gsub! gsub),     input: 'gsuv!', dictionary: %w(sub gsub gsub!)
-    assert_spell %w(sub! sub gsub!), input: 'ssub!', dictionary: %w(sub sub! gsub gsub!)
+    assert_spell %w(sub! sub gsub!), input: 'ssub!', dictionary: %w(sub sub! gsub sub gsub!)
 
     group_methods = %w(groups group_url groups_url group_path)
     assert_spell 'groups', input: 'group',  dictionary: group_methods


### PR DESCRIPTION
I have noticed duplications in suggestions when ActiveSupport's TimeWithZone objects using the Comparable mixin are called with a misspelled method.

```
=> Time.zone.now.between(1.hour.ago, 1.hour.from_now)
NoMethodError: undefined method `between' for Fri, 24 Mar 2017 15:30:47 UTC +00:00:Time
Did you mean?  between?
Did you mean?  between?
```

I am having trouble testing the fix locally and would love advice on how to test that my change has made a difference.

