### PR TITLE
Update Ruby to lastet version 2.4.1 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ after_success:
   - bundle exec rake benchmark:memory
 
 rvm:
-  - 2.4.0
+  - 2.4.1
   - ruby-head


### PR DESCRIPTION
Hello,

I want to use the latest version Ruby 2.4.1 in the `.travis.yml`.

Thanks.
