### PR TITLE
Adjust console display where rake task not found

### DIFF
--- a/lib/did_you_mean/core_ext/rake_task_manager.rb
+++ b/lib/did_you_mean/core_ext/rake_task_manager.rb
@@ -9,7 +9,7 @@ module DidYouMean
 
         raise error, (error.to_s << message), error.backtrace
       rescue
-        raise error, error.to_s, error.backtrace
+        raise error, error.to_s, Rake.application.options.trace ? error.backtrace : ''
       end
     end
   end


### PR DESCRIPTION
The suggestion to rake task name is awesome. Thanks for the wonderful feature.

When I specify an undefined task name, a backtrace is displayed.

```console
% rake undefined_task
rake aborted!
Don't know how to build task 'undefined_task' (see --tasks)
/Users/koic/src/github.com/yuki24/did_you_mean/lib/did_you_mean/core_ext/rake_task_manager.rb:4:in `[]'
(See full trace by running task with --trace)
```

AFAIK, it is not displayed in the original rake.

This PR changes to the same behavior as the original rake.

```console
% rake undefined_task
rake aborted!
Don't know how to build task 'undefined_task' (see --tasks)

(See full trace by running task with --trace)
```

Thank you.