### PR TITLE
prohibit including `NameErrorCheckers`

### DIFF
--- a/lib/did_you_mean/spell_checkers/name_error_checkers.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers.rb
@@ -2,12 +2,8 @@ require 'did_you_mean/spell_checkers/name_error_checkers/class_name_checker'
 require 'did_you_mean/spell_checkers/name_error_checkers/variable_name_checker'
 
 module DidYouMean
-  module NameErrorCheckers
-    def self.included(*)
-      raise "Do not include this module since it overrides Class.new method."
-    end
-
-    def self.new(exception)
+  class << (NameErrorCheckers = Object.new)
+    def new(exception)
       case exception.original_message
       when /uninitialized constant/
         ClassNameChecker


### PR DESCRIPTION
`included` is called after the module has been included, and not called when `Object#extend`.