### PR TITLE
Add ruby predefined objects to variable name checker

### DIFF
--- a/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
@@ -6,6 +6,7 @@ module DidYouMean
 
     NAMES_TO_EXCLUDE = { 'foo' => [:fork] }
     NAMES_TO_EXCLUDE.default = []
+    RB_PREDEFINED_OBJECTS = [false, true, :nil]
 
     def initialize(exception)
       @name       = exception.name.to_s.tr("@", "")
@@ -20,7 +21,7 @@ module DidYouMean
 
     def corrections
       @corrections ||= SpellChecker
-                     .new(dictionary: (lvar_names + method_names + ivar_names + cvar_names))
+                     .new(dictionary: (RB_PREDEFINED_OBJECTS + lvar_names + method_names + ivar_names + cvar_names))
                      .correct(name) - NAMES_TO_EXCLUDE[@name]
     end
   end

--- a/test/spell_checker_test.rb
+++ b/test/spell_checker_test.rb
@@ -10,6 +10,9 @@ class SpellCheckerTest < Minitest::Test
     assert_spell 'eval',  input: 'veal',  dictionary: ['email', 'fail', 'eval']
     assert_spell 'sub!',  input: 'suv!',  dictionary: ['sub', 'gsub', 'sub!']
     assert_spell 'sub',   input: 'suv',   dictionary: ['sub', 'gsub', 'sub!']
+    assert_spell 'nil',   input: 'nol',   dictionary: ['new', 'nil']
+    assert_spell 'false', input: 'fals',  dictionary: ['fail', 'false']
+    assert_spell 'true',  input: 'treu',  dictionary: ['try', 'true']
 
     assert_spell %w(gsub! gsub),     input: 'gsuv!', dictionary: %w(sub gsub gsub!)
     assert_spell %w(sub! sub gsub!), input: 'ssub!', dictionary: %w(sub sub! gsub gsub!)

--- a/test/spell_checking/variable_name_check_test.rb
+++ b/test/spell_checking/variable_name_check_test.rb
@@ -57,6 +57,31 @@ class VariableNameCheckTest < Minitest::Test
     assert_match "Did you mean?  person", error.to_s
   end
 
+  def test_corrections_include_ruby_predefined_objects
+    some_var = nil
+
+    false_error = assert_raises(NameError) do
+      some_var = fals
+    end
+
+    true_error = assert_raises(NameError) do
+      some_var = treu
+    end
+
+    nil_error = assert_raises(NameError) do
+      some_var = nol
+    end
+
+    assert_correction false, false_error.corrections
+    assert_match "Did you mean?  false", false_error.to_s
+
+    assert_correction true, true_error.corrections
+    assert_match "Did you mean?  true", true_error.to_s
+
+    assert_correction :nil, nil_error.corrections
+    assert_match "Did you mean?  nil", nil_error.to_s
+  end
+
   def test_corrections_include_instance_variable_name
     error = assert_raises(NameError){ @user.to_s }
 


### PR DESCRIPTION
Hi, @yuki24.
I'm thinking of adding predefined objects (`false`, `true`, and `nil`) in the variable name checker dictionary. Their 2.4 deprecated toplevel constants are already included, but the objects themselves are not.
The constants:
```ruby
a = NOL
# NameError: uninitialized constant NOL
# Did you mean?  NIL
b = FALS
# NameError: uninitialized constant FALS
# Did you mean?  FALSE
c = TREU
# NameError: uninitialized constant TREU
# Did you mean?  TRUE
```
but, the objects:
```ruby
a = nol
# NameError: undefined local variable or method `nol' for main:Object
b = fals
# NameError: undefined local variable or method `fals' for main:Object
c = treu
# NameError: undefined local variable or method `treu' for main:Object
```
I need to be reminded of these objects too.

I don't know how to get the predefined objects in the nice way so I just write them in an array.
Since `nil` return `""` when called with `to_s`, I replaced it with `:nil`.
Should I wrote all of them in symbols ([:false, :true, :nil]) to make it consistent with the others?

If this PR is merged:
```ruby
a = nol
# NameError: undefined local variable or method `nol' for main:Object
# Did you mean?  nil
b = fals
# NameError: undefined local variable or method `fals' for main:Object
# Did you mean?  false
c = treu
# NameError: undefined local variable or method `treu' for main:Object
# Did you mean?  true
```