### PR TITLE
Suggest global variables

### DIFF
--- a/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
@@ -2,7 +2,7 @@
 
 module DidYouMean
   class VariableNameChecker
-    attr_reader :name, :method_names, :lvar_names, :ivar_names, :cvar_names
+    attr_reader :name, :method_names, :gvar_names, :lvar_names, :ivar_names, :cvar_names
 
     NAMES_TO_EXCLUDE = { 'foo' => [:fork] }
     NAMES_TO_EXCLUDE.default = []
@@ -10,6 +10,7 @@ module DidYouMean
 
     def initialize(exception)
       @name       = exception.name.to_s.tr("@", "")
+      @gvar_names = global_variables.select {|g| g[/\$[A-Za-z]/] }
       @lvar_names = exception.respond_to?(:local_variables) ? exception.local_variables : []
       receiver    = exception.receiver
 
@@ -21,7 +22,7 @@ module DidYouMean
 
     def corrections
       @corrections ||= SpellChecker
-                     .new(dictionary: (RB_PREDEFINED_OBJECTS + lvar_names + method_names + ivar_names + cvar_names))
+                     .new(dictionary: (RB_PREDEFINED_OBJECTS + gvar_names + lvar_names + method_names + ivar_names + cvar_names))
                      .correct(name) - NAMES_TO_EXCLUDE[@name]
     end
   end

--- a/test/spell_checking/variable_name_check_test.rb
+++ b/test/spell_checking/variable_name_check_test.rb
@@ -49,6 +49,15 @@ class VariableNameCheckTest < Minitest::Test
     assert_match "Did you mean?  from_module", error.to_s
   end
 
+  def test_corrections_include_global_variable_name
+    error = assert_raises(NameError) do
+      stin
+    end
+
+    assert_correction :$stdin, error.corrections
+    assert_match "Did you mean?  $stdin", error.to_s
+  end
+
   def test_corrections_include_local_variable_name
     person = person = nil
     error = (eprson rescue $!) # Do not use @assert_raises here as it changes a scope.


### PR DESCRIPTION
Hi, @yuki24.
I'm thinking of adding global variables to suggestions.

Previously:
```ruby
STIN
# NameError: uninitialized constant STIN
# Did you mean?  STDIN
# Nice correction. But, this one
stin
# NameError: undefined local variable or method `stin' for main:Object
# Did you mean?  String
```

After this commit:
```ruby
stin
# NameError: undefined local variable or method `stin' for main:Object
# Did you mean?  $stdin
```

I also cleaned up the list of global variables so that it doesn't contain special characters or numbers that will never trigger NameError in the first place.