### PR TITLE
Refactor correct method

### DIFF
--- a/lib/did_you_mean/spell_checker.rb
+++ b/lib/did_you_mean/spell_checker.rb
@@ -10,23 +10,24 @@ module DidYouMean
     end
 
     def correct(input)
-      input     = normalize(input)
-      threshold = input.length > 3 ? 0.834 : 0.77
+      input        = normalize(input)
+      input_length = input.length
+      threshold    = input_length > 3 ? 0.834 : 0.77
 
-      words = @dictionary.select {|word| JaroWinkler.distance(normalize(word), input) >= threshold }
-      words.reject! {|word| input == word.to_s }
+      words = @dictionary.reject {|word| input == word.to_s }
+      words.select! {|word| JaroWinkler.distance(normalize(word), input) >= threshold }
       words.sort_by! {|word| JaroWinkler.distance(word.to_s, input) }
       words.reverse!
 
       # Correct mistypes
-      threshold   = (input.length * 0.25).ceil
+      threshold   = (input_length * 0.25).ceil
       corrections = words.select {|c| Levenshtein.distance(normalize(c), input) <= threshold }
 
       # Correct misspells
       if corrections.empty?
         corrections = words.select do |word|
           word   = normalize(word)
-          length = input.length < word.length ? input.length : word.length
+          length = input_length < word.length ? input_length : word.length
 
           Levenshtein.distance(word, input) < length
         end.first(1)


### PR DESCRIPTION
Hi, @yuki24 .
I noticed two things that I think can be improved:
1. I noticed that `input.length` is called several times, even within `words` iteration when `corrections` is still empty. So, I think storing the length in a variable is a good practice.
2. Also, I think `reject`ing a word if it's the same as the input is better if done earlier so that `select` doesn't need to do extra work for the rejected word (if any).