### PR TITLE
add ruby 2.6 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ after_success:
 
 rvm:
   - 2.5.3
+  - 2.6.0
   - ruby-head


### PR DESCRIPTION
This PR adds ruby 2.6.0 into Travis. 