### PR TITLE
Add a public API for registering an error

### DIFF
--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -85,15 +85,16 @@ require 'did_you_mean/tree_spell_checker'
 module DidYouMean
   # Map of error types and spell checker objects.
   SPELL_CHECKERS = Hash.new(NullChecker)
+  SPELL_CHECKERS["NoMethodError"] = MethodNameChecker
 
-  SPELL_CHECKERS.merge!({
-    "NameError"     => NameErrorCheckers,
-    "NoMethodError" => MethodNameChecker,
-    "KeyError"      => KeyErrorChecker
-  })
+  # Adds +DidYouMean+ functionality to an error using a given spell checker
+  def self.correct_error(error_class, spell_checker)
+    SPELL_CHECKERS[error_class.name] = spell_checker
+    error_class.prepend(Correctable)
+  end
 
-  NameError.prepend DidYouMean::Correctable
-  KeyError.prepend DidYouMean::Correctable
+  correct_error NameError, NameErrorCheckers
+  correct_error KeyError, KeyErrorChecker
 
   # Returns the currenctly set formatter. By default, it is set to +DidYouMean::Formatter+.
   def self.formatter

--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -85,16 +85,16 @@ require 'did_you_mean/tree_spell_checker'
 module DidYouMean
   # Map of error types and spell checker objects.
   SPELL_CHECKERS = Hash.new(NullChecker)
-  SPELL_CHECKERS["NoMethodError"] = MethodNameChecker
 
   # Adds +DidYouMean+ functionality to an error using a given spell checker
   def self.correct_error(error_class, spell_checker)
     SPELL_CHECKERS[error_class.name] = spell_checker
-    error_class.prepend(Correctable)
+    error_class.prepend(Correctable) unless error_class < Correctable
   end
 
   correct_error NameError, NameErrorCheckers
   correct_error KeyError, KeyErrorChecker
+  correct_error NoMethodError, MethodNameChecker
 
   # Returns the currenctly set formatter. By default, it is set to +DidYouMean::Formatter+.
   def self.formatter


### PR DESCRIPTION
Hey there - I was wondering if it might be possible to add a public API in order to register spell checkers. It's a pretty small change, but ergonomically it feels better than merging into a hash. I've added did_you_mean functionality to both thor and rubygems and it would feel better to call a blessed method.

Let me know what you think! Thanks for the great tool!